### PR TITLE
Add new Tabbing stragety for root blocks.

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -3,6 +3,7 @@
 The configuration options object is of the following form:
 ```js
 {
+  tabAction: 'escapeAndOut', // or 'escapeAndNextTemplate'
   spaceBehavesLikeTab: true,
   leftRightIntoCmdGoes: 'up',
   restrictMismatchedBrackets: true,
@@ -30,6 +31,10 @@ Global defaults may be set with [`MQ.config(global_config)`](Api_Methods.md#mqco
 
 
 # Configuration Options
+
+## tabAction
+
+`tabAction` configures the way MathQuill responds to Tab.  By default (`escapeAndOut`), {Shift-,}Tab will escape out of a template until it reaches the root block.  At that point MathQuill ignores the keystroke and allows the default browser behavior to occur.  The `escapeAndNextTemplate` approach similarly escapes out of templates, but when reaching the root block, the next {Shift-,}Tab will find the next template in the desired direction.  If there are no such templates, then MathQuill allows the default browser behavior to occur.
 
 ## spacesBehavesLikeTab
 

--- a/src/services/keystroke.js
+++ b/src/services/keystroke.js
@@ -154,12 +154,26 @@ Controller.open(function(_) {
     prayDirection(dir);
     var cursor = this.cursor;
 
-    // only prevent default of Tab if not in the root editable
-    if (cursor.parent !== this.root) e.preventDefault();
-
     // want to be a noop if in the root editable (in fact, Tab has an unrelated
     // default browser action if so)
-    if (cursor.parent === this.root) return;
+    if (cursor.parent === this.root) {
+        if ((key === 'Tab' || key === 'Shift-Tab') && cursor.options.tabAction === 'escapeAndNextTemplate') {
+            for (var n = cursor[dir]; n; n = n[dir]) {
+                if (!n.isEmpty()) {
+                    // only prevent default of Tab if not continuing in MQ field
+                    e.preventDefault();
+
+                    cursor.insAtDirEnd(-dir, n.ends[-dir]);
+                    return this.notify('move');
+                }
+            }
+        }
+
+        return;
+    }
+
+    // only prevent default of Tab if not continuing in MQ field
+    e.preventDefault();
 
     cursor.parent.moveOutOf(dir, cursor);
     return this.notify('move');

--- a/test/visual.html
+++ b/test/visual.html
@@ -125,6 +125,47 @@ $(function() {
 });
 </script>
 
+<h4>Tabbing</h4>
+
+<p><label for="escapeAndOut">Escape and Out</label> <span id="escapeAndOut">x^2 + \frac{x}{3+x} - \sqrt{5}</span></p>
+<p>Tab and Escape should behave the same, escaping out of templates.  At the root, Tab will move to the next focusable.</p>
+
+<script>
+$(function() {
+    MathQuill.MathField($('#escapeAndOut')[0], {
+        spaceBehavesLikeTab: true,
+        leftRightIntoCmdGoes: 'up',
+        restrictMismatchedBrackets: true,
+        sumStartsWithNEquals: true,
+        supSubsRequireOperand: true,
+        charsThatBreakOutOfSupSub: '+-=<>',
+        autoSubscriptNumerals: true,
+        autoCommands: 'pi theta sqrt sum',
+        autoOperatorNames: 'only'
+    });
+});
+</script>
+
+<p><label for="escapeAndNextTemplate">Escape and Next Template</label> <span id="escapeAndNextTemplate">x^2 + \frac{x}{3+x} - \sqrt{5}</span></p>
+<p>Tab and Escape should behave the same, escaping out of templates.  At the root, Tab will move to the next template or focusable when at an end.</p>
+
+<script>
+$(function() {
+    MathQuill.MathField($('#escapeAndNextTemplate')[0], {
+        spaceBehavesLikeTab: true,
+        leftRightIntoCmdGoes: 'up',
+        restrictMismatchedBrackets: true,
+        sumStartsWithNEquals: true,
+        supSubsRequireOperand: true,
+        charsThatBreakOutOfSupSub: '+-=<>',
+        autoSubscriptNumerals: true,
+        autoCommands: 'pi theta sqrt sum',
+        autoOperatorNames: 'only',
+        tabAction: 'escapeAndNextTemplate'
+    });
+});
+</script>
+
 <h3>Up/Down seeking and caching</h3>
 
 <p>


### PR DESCRIPTION
By default, MathQuill allows the browser to handle Tab in the standard way
when the cursor is in the root block.  This means that the user will move to
the next focusable element in tab order.  This behavior bypasses any templates
between the current cursor position and the end.

If templates are thought of as editable areas, like mini-textfields, this
approach feels unexpected to keyboard users, who would expect 'focus' to
traverse to the next 'field,' i.e. next template.

This commit adds a new configuration property: tabAction.  By default tabAction
simply uses the current behavior.  Users can specify a value of
'escapeAndTemplate' to allow Tabs from the root block to find the next template
or to move outside of the MathQuill field if no templates exist.